### PR TITLE
Rotate text hack, compress blank space

### DIFF
--- a/ILI9341_t3DMA.cpp
+++ b/ILI9341_t3DMA.cpp
@@ -34,7 +34,6 @@ const uint32_t * screen32e = (uint32_t*)&screen[0][0] + sizeof(screen) / 4;
 DMAChannel dmatx;
 volatile uint8_t rstop = 0;
 
-
 void dmaInterrupt(void) {
   ///  digitalWriteFast(1,!digitalReadFast(1));
   rstop = 1;
@@ -48,7 +47,6 @@ void ILI9341_t3DMA::begin(void) {
   const uint32_t maxLines = (65536 / bytesPerLine);
   uint32_t i = 0, sum = 0, lines;
   do {
-
 	//Source:
 	lines = min(maxLines, ILI9341_TFTHEIGHT - sum);
 	uint32_t len = lines * bytesPerLine;
@@ -87,11 +85,9 @@ void ILI9341_t3DMA::start(void) {
 }
 
 void ILI9341_t3DMA::fill(void) {
-
   for (int y = 0; y < ILI9341_TFTHEIGHT; y++)
 	for (int x = 0; x < ILI9341_TFTWIDTH; x++)
 	  writedata16_cont(screen[y][x]);
-
 };
 
 void ILI9341_t3DMA::refresh(void) {
@@ -99,7 +95,6 @@ void ILI9341_t3DMA::refresh(void) {
 	start();
 	fill();//TODO : Why is fill() needed ?
 	started = 1;
-
   }
   dmasettings[SCREEN_DMA_NUM_SETTINGS - 1].TCD->CSR &= ~DMA_TCD_CSR_DREQ; //disable "disableOnCompletion"
   SPI0_RSER |= SPI_RSER_TFFF_DIRS |	 SPI_RSER_TFFF_RE;	 // Set DMA Interrupt Request Select and Enable register
@@ -111,7 +106,7 @@ void ILI9341_t3DMA::refresh(void) {
 
 void ILI9341_t3DMA::stopRefresh(void) {
   dmasettings[SCREEN_DMA_NUM_SETTINGS - 1].disableOnCompletion();
-  //wait();  
+  wait();  
   SPI.endTransaction();
   autorefresh = 0;
 }
@@ -130,10 +125,8 @@ void ILI9341_t3DMA::wait(void) {
 }
 
 void ILI9341_t3DMA::dfillScreen(uint16_t color) {
-
   uint32_t col32 = (color << 16) | color;
   uint32_t * p = screen32;
-
   do {
 	*p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32;
 	*p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32; *p++ = col32;

--- a/ILI9341_t3DMA.h
+++ b/ILI9341_t3DMA.h
@@ -52,6 +52,10 @@ class ILI9341_t3DMA: public ILI9341_t3
 	void dfillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color); // fill a rectangle
 	void dwriteRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors);//TODO
 
+     
+	void ddrawRotChar(unsigned char c, bool compress);
+	void ddrawRotText(const  char* c, bool compress=0);
+	
 	// from Adafruit_GFX.h
 	void ddrawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
 	void ddrawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, uint16_t color);

--- a/examples/ILI9341_T3_DMArotateCompress/rotTextExample.ino
+++ b/examples/ILI9341_T3_DMArotateCompress/rotTextExample.ino
@@ -1,0 +1,38 @@
+#include "SPI.h"
+#include <ILI9341_t3DMA.h>
+
+//THESE ARE ALT PINS! for use with audio shield
+#define TFT_DC      20
+#define TFT_CS      21
+#define TFT_RST    255  
+#define TFT_MOSI     7
+#define TFT_SCLK    14
+#define TFT_MISO    12
+
+ILI9341_t3DMA tft = ILI9341_t3DMA(TFT_CS, TFT_DC, TFT_RST, TFT_MOSI, TFT_SCLK, TFT_MISO);
+
+void setup() {
+  tft.begin();
+  Serial.begin(9600);
+  while (!Serial) ;
+  tft.refresh();
+}
+
+int x=0;
+void loop(void) {
+  x++;
+  testText();
+  delay(10);
+}
+
+unsigned long testText() {
+ // tft.dfillScreen(ILI9341_BLACK);
+ //drawRotText( unsigned char* Text, bool CompressBlankSpace)
+  tft.setTextColor(ILI9341_WHITE,ILI9341_BLACK); 
+  tft.setCursor(100, x);
+  tft.ddrawRotText("abcdef ghijklm nopqrstuv wxyz1234 567890",1);
+ 
+  tft.setTextColor(ILI9341_WHITE,ILI9341_RED); 
+  tft.setCursor(140, x);
+  tft.ddrawRotText("abcdef ghijklm nopqrstuv wxyz1234 567890");
+}


### PR DESCRIPTION
A function for drawing rotated text without any font or size support.
Same direction as rotate(3).

Supports colored text, transparent and color background, and compression that limits space between characters to a single pixel.
