### PR TITLE
Text rotation hack and white space compression

### DIFF
--- a/ILI9341_t3DMA.cpp
+++ b/ILI9341_t3DMA.cpp
@@ -905,3 +905,57 @@ void ILI9341_t3DMA::ddrawFontBits(uint32_t bits, uint32_t numbits, uint32_t x, u
 	} while (repeat);
 #endif
 }
+
+void ILI9341_t3DMA::ddrawRotText(const char* c, bool compress) {
+  while (*c != '\0') {
+  	if (*c != ' ') ddrawRotChar(*c++, compress);
+  	else  {
+	   cursor_y -= 3; 
+	   if (textcolor != textbgcolor) dfillRect(max(0,cursor_x-7), max(0,cursor_y+1), 8, 3, textbgcolor);
+	   c++;
+	}
+  }
+}
+
+void ILI9341_t3DMA::ddrawRotChar(unsigned char c, bool compress) {
+  uint_fast8_t j = 0;
+  uint_fast16_t c5 = c * 5;
+  uint16_t *color;
+  uint16_t xAdjusted =  cursor_y;
+  bool xFlag = false;
+  if (textcolor != textbgcolor) {
+    while (j < 5) {
+      uint_fast8_t mask = 0x01, i = 8;
+      xFlag = false;
+      while (i--) {
+        if (glcdfont[c5 + j] & mask) { 
+        	ddrawPixel( cursor_x - i,  cursor_y, textcolor);
+          xFlag = true;
+        }
+        else ddrawPixel( cursor_x - i,  cursor_y, textbgcolor);
+        mask = mask << 1;
+      }
+      if (xFlag || !compress) cursor_y--;
+      mask = mask << 1;
+      j++;
+    }
+    ddrawFastHLine(max(0,cursor_x-7), max(0,cursor_y), 8, textbgcolor);
+    cursor_y--;
+  }
+  else {
+    while (j < 5) {
+      uint_fast8_t mask = 0x01, i = 8;
+      xFlag = false;
+      while (i--) {
+        if (glcdfont[c5 + j] & mask) {
+          ddrawPixel( cursor_x - i,  cursor_y, textcolor);
+          xFlag = true;
+        }
+        mask = mask << 1;
+      } 
+      if (xFlag || !compress) cursor_y--;
+      j++;
+    }
+    cursor_y--;
+  }
+}

--- a/ILI9341_t3DMA.h
+++ b/ILI9341_t3DMA.h
@@ -51,7 +51,10 @@ class ILI9341_t3DMA: public ILI9341_t3
 	void ddrawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
 	void dfillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color); // fill a rectangle
 	void dwriteRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors);//TODO
-
+	
+	void ddrawRotChar(unsigned char c, bool compress);
+	void ddrawRotText(const  char* c, bool compress=0);
+	
 	// from Adafruit_GFX.h
 	void ddrawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
 	void ddrawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, uint16_t color);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# ILI9341_t3DMA
+Descendant of ILI9341_t3, but DMA and 150KB Buffer in RAM (T3.5 / T3.6 only)
+
+Added a rotated text hack that supports the default 5x7 font, color text/background, and white space removal. 

--- a/examples/ILI9341_RotateCompressTextHack/rotTextExample.ino
+++ b/examples/ILI9341_RotateCompressTextHack/rotTextExample.ino
@@ -1,0 +1,38 @@
+#include "SPI.h"
+#include <ILI9341_t3DMA.h>
+
+//THESE ARE THE ALT PINS! for use with audio shield
+#define TFT_DC      20
+#define TFT_CS      21
+#define TFT_RST    255  
+#define TFT_MOSI     7
+#define TFT_SCLK    14
+#define TFT_MISO    12
+
+ILI9341_t3DMA tft = ILI9341_t3DMA(TFT_CS, TFT_DC, TFT_RST, TFT_MOSI, TFT_SCLK, TFT_MISO);
+
+void setup() {
+  tft.begin();
+  Serial.begin(9600);
+  while (!Serial) ;
+  tft.refresh();
+}
+
+int x=0;
+void loop(void) {
+  x++;
+  testText();
+  delay(10);
+}
+
+unsigned long testText() {
+ // tft.dfillScreen(ILI9341_BLACK);
+ //drawRotText( unsigned char* Text, bool CompressBlankSpace)
+  tft.setTextColor(ILI9341_WHITE,ILI9341_BLACK); 
+  tft.setCursor(100, x);
+  tft.ddrawRotText("abcdef ghijklm nopqrstuv wxyz1234 567890",1);
+ 
+  tft.setTextColor(ILI9341_WHITE,ILI9341_RED); 
+  tft.setCursor(140, x);
+  tft.ddrawRotText("abcdef ghijklm nopqrstuv wxyz1234 567890");
+}


### PR DESCRIPTION
ddrawRotText will draw rotated text with color or transparent
background. Optional boolean to compress white space. Doesn't support
extra fonts or textsize.
